### PR TITLE
chore: update crate versions to 25.9.0 to sync with upstream Anki rel…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,14 +5228,14 @@ dependencies = [
 
 [[package]]
 name = "sync-storage-api"
-version = "0.1.0"
+version = "25.9.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "sync-storage-backends"
-version = "0.1.0"
+version = "25.9.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "sync-storage-config"
-version = "0.1.0"
+version = "25.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "sync-storage-server"
-version = "0.0.0"
+version = "25.9.0"
 dependencies = [
  "anki",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -347,7 +347,18 @@ To run only the sync-storage-config tests:
 cargo test -p sync-storage-config
 ```
 
-## Versioning 
+## Versioning
+
+### Crate versions
+
+Custom crates (`sync-storage-api`, `sync-storage-backends`, `sync-storage-config`,
+`sync-storage-server`) are versioned as `<anki-major>.<anki-minor>.<anki-patch>` in semver form —
+e.g. Anki `25.09` → `25.9.0`, Anki `25.09.2` → `25.9.2`. Leading zeros are dropped (Cargo strips
+them anyway). The `-rX` revision counter is **not** baked into the crate version to avoid collisions
+with upstream patch releases. When upgrading rslib, bump all four crate versions to match the new
+upstream version.
+
+### Git tags
 
 Tags follow `v<anki-version>-r<revision>` (e.g. `v25.09-r1`).
 
@@ -382,6 +393,7 @@ that needs updating.
 
 Quick checklist:
 
+- [ ] `sync-storage-*/Cargo.toml` — bump `version` to match new Anki version (e.g. `25.9.2`)
 - [ ] `rslib/Cargo.toml` — `sync-storage-api` in `[dependencies]`, `anyhow` in `[dev-dependencies]`
 - [ ] `rslib/sync/Cargo.toml` — `sync-storage-server` in both platform dependency blocks
 - [ ] `rslib/sync/main.rs` — calls `sync_storage_server::run()` not `SimpleServer::run()`

--- a/sync-storage-api/Cargo.toml
+++ b/sync-storage-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sync-storage-api"
-version = "0.1.0"
+version = "25.9.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 

--- a/sync-storage-backends/Cargo.toml
+++ b/sync-storage-backends/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sync-storage-backends"
-version = "0.1.0"
+version = "25.9.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 

--- a/sync-storage-config/Cargo.toml
+++ b/sync-storage-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sync-storage-config"
-version = "0.1.0"
+version = "25.9.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 

--- a/sync-storage-server/Cargo.toml
+++ b/sync-storage-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sync-storage-server"
-version.workspace = true
+version = "25.9.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
…ease